### PR TITLE
Adds 20.04.0 Nextflow version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nxf_ver: ['20.01.0', '']
+        nxf_ver: ['20.01.0', '20.04.0', '']
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Install Nextflow


### PR DESCRIPTION
## Overview

Adds 20.04.0 Nextflow version in CI

## Purpose

To account for all Nextflow versions that are available in CloudOS.

## Changes

- [X] Adds an additional Nextflow version to `.github/workflows/ci.yml`
